### PR TITLE
CI: Adapt Makefile and ci workflow to be similar to other repositories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,14 @@ jobs:
   lint:
     uses: heathcliff26/ci/.github/workflows/golang-lint.yaml@main
 
+  unit-tests:
+    uses: heathcliff26/ci/.github/workflows/golang-unit-tests.yaml@main
+
   build:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
     needs:
       - lint
+      - unit-tests
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,30 +20,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -ldflags="-w -s" -o
 ###############################################################################
 
 ###############################################################################
-# BEGIN test-stage
-# Run the tests in the container
-FROM docker.io/library/golang:1.23.1@sha256:efa59042e5f808134d279113530cf419e939d40dab6475584a13c62aa8497c64 AS test-stage
-
-WORKDIR /app
-
-COPY --from=build-stage /app /app
-# Not needed for testing, but needed for later stage
-COPY --from=build-stage /cloudflare-dyndns /
-
-RUN go test -v ./...
-
-#
-# END test-stage
-###############################################################################
-
-###############################################################################
 # BEGIN combine-stage
 # Combine all outputs, to enable single layer copy for the final image
 FROM scratch AS combine-stage
 
-COPY --from=test-stage /cloudflare-dyndns /
+COPY --from=build-stage /cloudflare-dyndns /
 
-COPY --from=test-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 #
 # END combine-stage

--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,32 @@ REPOSITORY ?= localhost
 CONTAINER_NAME ?= cloudflare-dyndns
 TAG ?= latest
 
-GO_BUILD_FLAGS ?= -ldflags="-w -s"
-
 default: build
 
 build:
+	hack/build.sh
+
+image:
 	podman build -t $(REPOSITORY)/$(CONTAINER_NAME):$(TAG) .
 
-go-build:
-	go build $(GO_BUILD_FLAGS) -o bin/cloudflare-dyndns ./cmd/
+test:
+	go test -v -race ./...
 
-go-test:
-	go test -v ./...
+update-deps:
+	hack/update-deps.sh
+
+coverprofile:
+	hack/coverprofile.sh
+
+lint:
+	golangci-lint run -v
 
 .PHONY: \
 	default \
 	build \
-	go-build \
-	go-test \
+	image \
+	test \
+	update-deps \
+	coverprofile \
+	lint \
 	$(NULL)

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
+
+bin_dir="${base_dir}/bin"
+
+GOOS="${GOOS:-$(go env GOOS)}"
+GOARCH="${GOARCH:-$(go env GOARCH)}"
+
+GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
+
+# if [ "${RELEASE_VERSION}" != "" ]; then
+#     echo "Building release version ${RELEASE_VERSION}"
+#     GO_LD_FLAGS+=" -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.version=${RELEASE_VERSION}"
+# fi
+
+output_name="${bin_dir}/cloudflare-dyndns"
+if [ "${GOOS}" == "windows" ]; then
+    output_name="${output_name}.exe"
+fi
+
+pushd "${base_dir}" >/dev/null
+
+echo "Building $(basename "${output_name}")"
+GOOS="${GOOS}" GOARCH="${GOARCH}" CGO_ENABLED=0 go build -ldflags="${GO_LD_FLAGS}" -o "${output_name}" ./cmd/...


### PR DESCRIPTION
Remove the unit tests from the Dockerfile and run them as a separate step
during CI instead.

Add makefile commands for updating deps, lint and coverprofile.
Rename commands to be equal to other repos (e.g. fleetlock).
Add build script for binary.