### PR TITLE
Add version information to binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,22 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Use to set tag, default: rolling"
+        type: string
+        default: "rolling"
+        required: false
+      dry-run:
+        description: "Do not push image"
+        type: boolean
+        default: false
+        required: false
+      latest:
+        description: "Tag latest"
+        type: boolean
+        default: false
+        required: false
   push:
     branches: ["main"]
     paths:
@@ -33,6 +49,8 @@ jobs:
       packages: write
     with:
       dockerfile: Dockerfile
-      tag: slim
-      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+      tag: "${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
+      tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
+      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
+      build-args: "RELEASE_VERSION=${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
     secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.1@sha256:efa59042e5
 
 ARG BUILDPLATFORM
 ARG TARGETARCH
+ARG RELEASE_VERSION
 
 WORKDIR /app
 
@@ -12,8 +13,9 @@ COPY vendor ./vendor
 COPY go.mod go.sum ./
 COPY cmd ./cmd
 COPY pkg ./pkg
+COPY hack ./hack
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -ldflags="-w -s" -o /cloudflare-dyndns ./cmd/
+RUN --mount=type=bind,target=/app/.git,source=.git GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
 
 #
 # END build-stage
@@ -24,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" go build -ldflags="-w -s" -o
 # Combine all outputs, to enable single layer copy for the final image
 FROM scratch AS combine-stage
 
-COPY --from=build-stage /cloudflare-dyndns /
+COPY --from=build-stage /app/bin/cloudflare-dyndns /
 
 COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ The client package can also be used as a golang API, should you want to build yo
 
 There are different flavors of the image:
 
-| Tag(s)           | Describtion                                                                                                                                                                              |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **latest, slim** | Contains only the golang binary                                                                                                                                                          |
-| **php**          | Deprecated: Contains the original php script from [Fritz!Box DynDNS Script for Cloudflare](https://github.com/1rfsNet/Fritz-Box-Cloudflare-DynDNS) and is based on `php:apache-bookworm` |
+| Tag(s)      | Description                                                 |
+| ----------- | ----------------------------------------------------------- |
+| **latest**  | Last released version of the image                          |
+| **rolling** | Rolling update of the image, always build from main branch. |
+| **vX.Y.Z**  | Released version of the image                               |
 
 ## Usage
 
@@ -50,6 +51,7 @@ Usage of cloudflare-dyndns:
         Used together with -config, when set will expand enviroment variables in config
   -mode string
         Set what mode to run, options are "server", "client" and "relay" (default "server")
+  -v    Print the version information and exit
 ```
 An example config can be found [here](configs/example-config.yaml).
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -10,12 +11,14 @@ import (
 	"github.com/heathcliff26/cloudflare-dyndns/pkg/dyndns"
 	"github.com/heathcliff26/cloudflare-dyndns/pkg/relay"
 	"github.com/heathcliff26/cloudflare-dyndns/pkg/server"
+	"github.com/heathcliff26/cloudflare-dyndns/pkg/version"
 )
 
 var (
-	mode       string
-	configPath string
-	env        bool
+	mode         string
+	configPath   string
+	env          bool
+	printVersion bool
 )
 
 // Initialize the needed flags for cli options
@@ -23,10 +26,16 @@ func init() {
 	flag.StringVar(&mode, "mode", config.MODE_SERVER, "Set what mode to run, options are \""+config.MODE_SERVER+"\", \""+config.MODE_CLIENT+"\" and \""+config.MODE_RELAY+"\"")
 	flag.StringVar(&configPath, "config", "", "Path to config file, can be empty when running in mode "+config.MODE_SERVER)
 	flag.BoolVar(&env, "env", false, "Used together with -config, when set will expand enviroment variables in config")
+	flag.BoolVar(&printVersion, "v", false, "Print the version information and exit")
 }
 
 func main() {
 	flag.Parse()
+
+	if printVersion {
+		fmt.Print(version.Version())
+		os.Exit(0)
+	}
 
 	cfg, err := config.LoadConfig(configPath, mode, env)
 	if err != nil {

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -11,10 +11,10 @@ GOARCH="${GOARCH:-$(go env GOARCH)}"
 
 GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
 
-# if [ "${RELEASE_VERSION}" != "" ]; then
-#     echo "Building release version ${RELEASE_VERSION}"
-#     GO_LD_FLAGS+=" -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.version=${RELEASE_VERSION}"
-# fi
+if [ "${RELEASE_VERSION}" != "" ]; then
+    echo "Building release version ${RELEASE_VERSION}"
+    GO_LD_FLAGS+=" -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.version=${RELEASE_VERSION}"
+fi
 
 output_name="${bin_dir}/cloudflare-dyndns"
 if [ "${GOOS}" == "windows" ]; then

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,33 @@
+package version
+
+import (
+	"runtime"
+	"runtime/debug"
+)
+
+const Name = "cloudflare-dyndns"
+
+var version = "devel"
+
+func Version() string {
+	var commit string
+	buildinfo, _ := debug.ReadBuildInfo()
+	for _, item := range buildinfo.Settings {
+		if item.Key == "vcs.revision" {
+			commit = item.Value
+			break
+		}
+	}
+	if len(commit) > 7 {
+		commit = commit[:7]
+	} else if commit == "" {
+		commit = "Unknown"
+	}
+
+	result := Name + ":\n"
+	result += "    Version: " + version + "\n"
+	result += "    Commit:  " + commit + "\n"
+	result += "    Go:      " + runtime.Version() + "\n"
+
+	return result
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,30 @@
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	result := Version()
+
+	lines := strings.Split(result, "\n")
+
+	assert := assert.New(t)
+
+	if !assert.Equal(5, len(lines), "Should have enough lines") {
+		t.FailNow()
+	}
+	assert.Contains(lines[0], Name)
+	assert.Contains(lines[1], version)
+
+	commit := strings.Split(lines[2], ":")
+	assert.NotEmpty(strings.TrimSpace(commit[1]))
+
+	assert.Contains(lines[3], runtime.Version())
+
+	assert.Equal("", lines[4], "Should have trailing newline")
+}


### PR DESCRIPTION
Add version information to the binary. It can be printed with the `-v` flag. Adapt the CI to include the version information during build. Use the opportunity to remove old php tag from README.