### PR TITLE
Dockerfile: Drop expose option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,6 @@ WORKDIR /
 
 COPY --from=combine-stage / /
 
-EXPOSE 8080
-
 USER 1001
 
 ENTRYPOINT ["/cloudflare-dyndns"]


### PR DESCRIPTION
Only the server mode needs to expose the mode. It is better that it is being done consciously by the user instead of automatically by the container runtime.