### PR TITLE
go.mod: Update go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/cloudflare-dyndns
 
-go 1.21
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
With the release of go1.23, go1.21 is no longer supported.