### PR TITLE
server: Add indentation to json body in response

### DIFF
--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -18,7 +18,7 @@ type Response struct {
 func sendResponse(rw http.ResponseWriter, msg string, success bool) {
 	res := Response{msg, success}
 
-	b, err := json.Marshal(res)
+	b, err := json.MarshalIndent(res, "", "  ")
 	if err != nil {
 		if success {
 			rw.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
To make responses more human readable, add indentation to the json response.