### PR TITLE
client: Fix IPv4/IPv6 only update to dual stack domain

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -205,11 +205,19 @@ func (c *cloudflareClient) Update() error {
 			)
 			switch record.Type {
 			case "A":
+				if c.Data().IPv4() == "" {
+					continue
+				}
+
 				v4 = true
 				if record.Content == c.Data().IPv4() {
 					continue
 				}
 			case "AAAA":
+				if c.Data().IPv6() == "" {
+					continue
+				}
+
 				v6 = true
 				if record.Content == c.Data().IPv6() {
 					continue

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -423,6 +423,40 @@ func TestUpdate(t *testing.T) {
 			},
 			UpdatedRecords: 1,
 		},
+		{
+			Name: "DualStackIPv4OnlyUpdate",
+			Data: singleStackDataIPv4,
+			Records: []cloudflareRecord{
+				{
+					Content: "100.100.100.120",
+					Type:    "A",
+					Id:      "1234567890",
+				},
+				{
+					Content: "fd69::dead",
+					Type:    "AAAA",
+					Id:      "1234567890",
+				},
+			},
+			UpdatedRecords: 1,
+		},
+		{
+			Name: "DualStackIPv6OnlyUpdate",
+			Data: singleStackDataIPv6,
+			Records: []cloudflareRecord{
+				{
+					Content: "100.100.100.100",
+					Type:    "A",
+					Id:      "1234567890",
+				},
+				{
+					Content: "fd69::1234",
+					Type:    "AAAA",
+					Id:      "1234567890",
+				},
+			},
+			UpdatedRecords: 1,
+		},
 	}
 
 	for _, tCase := range tMatrix {

--- a/pkg/dyndns/dyndns_test.go
+++ b/pkg/dyndns/dyndns_test.go
@@ -53,11 +53,19 @@ func TestClientDataSetFunctions(t *testing.T) {
 		err := d.SetIPv4("100.100.100.100")
 		assert.Equal(t, "100.100.100.100", d.IPv4())
 		assert.Nil(t, err)
+
+		err = d.SetIPv4("")
+		assert.Equal(t, "", d.IPv4())
+		assert.Nil(t, err)
 	})
 	t.Run("SetIPv6", func(t *testing.T) {
 		d := &ClientData{}
 		err := d.SetIPv6("fd00::dead")
 		assert.Equal(t, "fd00::dead", d.IPv6())
+		assert.Nil(t, err)
+
+		err = d.SetIPv6("")
+		assert.Equal(t, "", d.IPv6())
 		assert.Nil(t, err)
 	})
 }


### PR DESCRIPTION
When updating a single IP on a dual stack domain, it should not fail.

Fixes: #35