### PR TITLE
version: Use the version from build info

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,6 @@ jobs:
       tag: "${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
       tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
-      build-args: "RELEASE_VERSION=${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
     secrets: inherit
 
   build-packages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
 ###############################################################################
 # BEGIN build-stage
 # Compile the binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23.5@sha256:8c10f21bec412f08f73aa7b97ca5ac5f28a39d8a88030ad8a339fd0a781d72b4 AS build-stage
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24.0@sha256:2b1cbf278ce05a2a310a3d695ebb176420117a8cfcfcc4e5e68a1bef5f6354da AS build-stage
 
 ARG BUILDPLATFORM
 ARG TARGETARCH
-ARG RELEASE_VERSION
 
 WORKDIR /app
 
-COPY vendor ./vendor
-COPY go.mod go.sum ./
-COPY cmd ./cmd
-COPY pkg ./pkg
-COPY hack ./hack
+COPY . ./
 
-RUN --mount=type=bind,target=/app/.git,source=.git GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
+RUN GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
 
 #
 # END build-stage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/cloudflare-dyndns
 
-go 1.22.0
+go 1.24.0
 
 require (
 	github.com/spf13/cobra v1.8.1

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -11,11 +11,6 @@ GOARCH="${GOARCH:-$(go env GOARCH)}"
 
 GO_LD_FLAGS="${GO_LD_FLAGS:-"-s"}"
 
-if [ "${RELEASE_VERSION}" != "" ]; then
-    echo "Building release version ${RELEASE_VERSION}"
-    GO_LD_FLAGS+=" -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.version=${RELEASE_VERSION}"
-fi
-
 output_name="${bin_dir}/cloudflare-dyndns"
 if [ "${1}" != "" ]; then
     output_name="${bin_dir}/${1}"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,7 +82,7 @@ func (c *Config) validateClient() error {
 		return dyndns.ErrMissingToken{}
 	}
 
-	if c.Client.Domains == nil || len(c.Client.Domains) < 1 {
+	if len(c.Client.Domains) < 1 {
 		return dyndns.ErrNoDomain{}
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"runtime"
 	"runtime/debug"
 
@@ -10,14 +9,13 @@ import (
 
 const Name = "cloudflare-dyndns"
 
-var version = "devel"
-
+// Create a new version command with the given app name
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information and exit",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Print(Version())
+			cmd.Print(VersionInfoString())
 		},
 	}
 	// Override to prevent parent function from running
@@ -26,7 +24,14 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// Return the version string
 func Version() string {
+	buildinfo, _ := debug.ReadBuildInfo()
+	return buildinfo.Main.Version
+}
+
+// Return a formated string containing the version, git commit and go version the app was compiled with.
+func VersionInfoString() string {
 	var commit string
 	buildinfo, _ := debug.ReadBuildInfo()
 	for _, item := range buildinfo.Settings {
@@ -42,7 +47,7 @@ func Version() string {
 	}
 
 	result := Name + ":\n"
-	result += "    Version: " + version + "\n"
+	result += "    Version: " + buildinfo.Main.Version + "\n"
 	result += "    Commit:  " + commit + "\n"
 	result += "    Go:      " + runtime.Version() + "\n"
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"testing"
 
@@ -18,17 +19,27 @@ func TestNewVersionCommand(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	result := Version()
+	assert := assert.New(t)
+
+	buildinfo, _ := debug.ReadBuildInfo()
+
+	assert.Equal(buildinfo.Main.Version, Version(), "Version should return the version from build info")
+}
+
+func TestVersionInfoString(t *testing.T) {
+	result := VersionInfoString()
 
 	lines := strings.Split(result, "\n")
 
 	assert := assert.New(t)
 
+	buildinfo, _ := debug.ReadBuildInfo()
+
 	if !assert.Equal(5, len(lines), "Should have enough lines") {
 		t.FailNow()
 	}
 	assert.Contains(lines[0], Name)
-	assert.Contains(lines[1], version)
+	assert.Contains(lines[1], buildinfo.Main.Version)
 
 	commit := strings.Split(lines[2], ":")
 	assert.NotEmpty(strings.TrimSpace(commit[1]))


### PR DESCRIPTION
With golang 1.24, the version derived from tag is now embedded by default. Use it instead, as it is better and easier than stamping it manually during build.
Ensure Dockerfile does not have a dirty repo by copying everything during build.
Require golang 1.24.