### PR TITLE
Fix code alerts found by gosec

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,6 +126,7 @@ func LoadConfig(path string, mode string, env bool) (Config, error) {
 		return c, nil
 	}
 
+	// #nosec G304 -- Local users can decide on their file path themselves.
 	f, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, err

--- a/pkg/dyndns/utils.go
+++ b/pkg/dyndns/utils.go
@@ -28,7 +28,7 @@ func HasIPv6Support() bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
+	defer conn.Close()
 	return true
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/heathcliff26/cloudflare-dyndns/pkg/client"
 	"github.com/heathcliff26/cloudflare-dyndns/pkg/config"
@@ -196,8 +197,10 @@ func (s *Server) router() *http.ServeMux {
 // Starts the server and exits with error if that fails
 func (s *Server) Run() error {
 	server := http.Server{
-		Addr:    s.Addr,
-		Handler: middleware.Logging(s.router()),
+		Addr:         s.Addr,
+		Handler:      middleware.Logging(s.router()),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 
 	var err error


### PR DESCRIPTION
Ensure that the http server has a sensible ReadTimeout. As all files and
requests made or send to the server should be small, the timeout can be set for
the whole request, instead of just the header.

Add #nosec comments with justification where appropiate.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>