### PR TITLE
CI: Update goreleaser to support rust cross compilation

### DIFF
--- a/.github/workflows/build-builder.yaml
+++ b/.github/workflows/build-builder.yaml
@@ -1,0 +1,29 @@
+---
+name: Build Builder Image
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [main]
+    paths:
+      - "hack/builder/*"
+  pull_request:
+    branches: [main]
+    paths:
+      - "hack/builder/*"
+      - ".github/workflows/build-builder.yaml"
+  merge_group:
+    branches: ["main"]
+
+jobs:
+  build:
+    uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      app: rust-builder
+      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+      context: hack/builder
+    secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,32 +90,15 @@ jobs:
     with:
       cmd: "make test-e2e"
 
-  # TODO: Replace with proper build-artifacts
-  build-binary:
+  build-artifacts:
     uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-          - arch: arm64
     with:
-      cmd: "make build"
-      artifact: "bin/cloudflare-dyndns"
-      artifact-name: "cloudflare-dyndns-${{ matrix.arch }}"
-      architecture: "${{ matrix.arch }}"
-  # build-artifacts:
-  #   uses: heathcliff26/ci/.github/workflows/golang-build.yaml@main
-  #   permissions:
-  #     contents: read
-  #   with:
-  #     release: "${{ github.event_name == 'pull_request' && 'devel' || inputs.tag == '' && 'rolling' || inputs.tag }}"
-  #     artifact: "dist/*"
-  #     artifact-name: "cloudflare-dyndns"
-  #     cmd: "make release"
-  #   secrets: inherit
+      cmd: "make release"
+      artifact: "dist/*"
+      artifact-name: "cloudflare-dyndns"
+    secrets: inherit
 
   build-image:
     uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
@@ -126,7 +109,7 @@ jobs:
       - test
       - validate
       - e2e
-      # TODO: - build-artifacts
+      - build-artifacts
     permissions:
       contents: read
       packages: write
@@ -147,7 +130,7 @@ jobs:
       - test
       - validate
       - e2e
-      # TODO: - build-artifacts
+      - build-artifacts
     permissions:
       contents: read
       packages: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,34 +6,73 @@ version: 2
 project_name: cloudflare-dyndns
 
 env:
-  - CGO_ENABLED=0
-  - RELEASE_VERSION={{ if index .Env "RELEASE_VERSION"  }}{{ .Env.RELEASE_VERSION }}{{ else }}devel{{ end }}
+  - CI_COMMIT_SHA={{ .FullCommit }}
+  - CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/x86_64-linux-gnu-gcc
+  - CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc
+  - CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=/usr/bin/x86_64-linux-musl-gcc
+  - CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=/usr/bin/aarch64-linux-musl-gcc
+  - PKG_CONFIG_ALLOW_CROSS=true
+
+before:
+  hooks:
+    - cargo fetch --locked
 
 builds:
-  - id: binary
+  - id: dynamic
+    builder: rust
     binary: cloudflare-dyndns
-    main: ./cmd/main.go
-    goos:
-      - linux
-    goarch:
-      - arm64
-      - amd64
+    tool: cargo
+    command: build
     flags:
-      - -trimpath
-    ldflags:
-      - -s -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.gitVersion={{ .Env.RELEASE_VERSION }} -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.gitCommit={{ .Commit }}
+      - --release
+    targets:
+      - x86_64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
+    env:
+      - >-
+        {{- if eq .Target "aarch64-unknown-linux-gnu" }}
+          PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig
+        {{- else if eq .Target "x86_64-unknown-linux-gnu" }}
+          PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-gnu/pkgconfig
+        {{- end }}
+  - id: static
+    builder: rust
+    binary: cloudflare-dyndns
+    tool: cargo
+    command: build
+    flags:
+      - --release
+      - --features=native-tls-vendored
+    targets:
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-musl
+    env:
+      - RUSTFLAGS=-C target-feature=+crt-static
+      - >-
+        {{- if eq .Target "aarch64-unknown-linux-musl" }}
+          PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-musl/pkgconfig
+        {{- else if eq .Target "x86_64-unknown-linux-musl" }}
+          PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-musl/pkgconfig
+        {{- end }}
   - id: compressed
+    builder: rust
     binary: cloudflare-dyndns
-    main: ./cmd/main.go
-    goos:
-      - linux
-    goarch:
-      - arm64
-      - amd64
+    tool: cargo
+    command: build
     flags:
-      - -trimpath
-    ldflags:
-      - -s -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.gitVersion={{ .Env.RELEASE_VERSION }} -X github.com/heathcliff26/cloudflare-dyndns/pkg/version.gitCommit={{ .Commit }}
+      - --release
+      - --features=native-tls-vendored
+    targets:
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-musl
+    env:
+      - RUSTFLAGS=-C target-feature=+crt-static
+      - >-
+        {{- if eq .Target "aarch64-unknown-linux-musl" }}
+          PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-musl/pkgconfig
+        {{- else if eq .Target "x86_64-unknown-linux-musl" }}
+          PKG_CONFIG_LIBDIR=/usr/lib/x86_64-linux-musl/pkgconfig
+        {{- end }}
 
 upx:
   - enabled: true
@@ -47,6 +86,31 @@ archives:
 nfpms:
   - id: openwrt
     file_name_template: "{{ .PackageName }}_v{{ .Version }}_openwrt-{{ .Arch }}"
+    ids:
+      - static
+    maintainer: Heathcliff <heathcliff@heathcliff.eu>
+    description: DDNS client for cloudflare
+    license: Apache 2.0
+    formats:
+      - ipk
+      - apk
+    dependencies:
+      - ca-bundle
+    bindir: /usr/sbin
+    contents:
+      - src: packages/openwrt/etc-config
+        dst: /etc/config/cloudflare-dyndns
+      - src: packages/openwrt/init-d.sh
+        dst: /etc/init.d/cloudflare-dyndns
+        file_info:
+          mode: 0755
+      - src: packages/openwrt/config.yaml
+        dst: /etc/cloudflare-dyndns/config.yaml
+    scripts:
+      postinstall: packages/openwrt/postinstall.sh
+      preremove: packages/openwrt/preremove.sh
+  - id: openwrt-compressed
+    file_name_template: "{{ .PackageName }}-compressed_v{{ .Version }}_openwrt-{{ .Arch }}"
     ids:
       - compressed
     maintainer: Heathcliff <heathcliff@heathcliff.eu>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +879,7 @@ checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,4 +81,5 @@ panic = "abort"
 
 [features]
 default = []
+native-tls-vendored = ["tokio-native-tls/vendored", "reqwest/native-tls-vendored"]
 e2e = []

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/library/rust:1.94.1
+
+LABEL   org.opencontainers.image.authors="heathcliff@heathcliff.eu" \
+        org.opencontainers.image.description="Builder and CI image for rust projects. Can be used to cross-compile." \
+        org.opencontainers.image.source="https://github.com/heathcliff26/cloudflare-dyndns" \
+        org.opencontainers.image.licenses="Apache-2.0" \
+        org.opencontainers.image.title="rust-builder"
+
+# renovate: datasource=github-releases depName=goreleaser/goreleaser extractVersion=^(?<version>.*)$
+ARG GORELEASER_VERSION=v2.15.2
+
+COPY install-deps.sh .
+RUN ./install-deps.sh
+
+WORKDIR /app

--- a/hack/builder/install-deps.sh
+++ b/hack/builder/install-deps.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -ex
+
+arches="amd64 arm64"
+
+case "$(uname -m)" in
+    x86_64|amd64)
+        current_arch="amd64"
+        ;;
+    aarch64|arm64)
+        current_arch="arm64"
+        ;;
+    *)
+        current_arch="$(uname -m)"
+esac
+
+for arch in ${arches}; do
+    if [ "${arch}" != "${current_arch}" ]; then
+        echo "Adding architecture ${arch}"
+        dpkg --add-architecture "${arch}"
+    fi
+done
+
+echo "Updating package lists"
+apt-get update
+
+echo "Installing native dependencies"
+apt-get install -y --no-install-recommends --no-install-suggests \
+        musl-tools \
+        upx
+
+for arch in ${arches}; do
+    case "${arch}" in
+        amd64)
+            pkg_arch="x86-64"
+            rust_target="x86_64-unknown-linux-gnu"
+            musl_target="x86_64-unknown-linux-musl"
+            musl_toolchain="x86_64-linux-musl-cross.tgz"
+            ;;
+        arm64)
+            pkg_arch="aarch64"
+            rust_target="aarch64-unknown-linux-gnu"
+            musl_target="aarch64-unknown-linux-musl"
+            musl_toolchain="aarch64-linux-musl-cross.tgz"
+            ;;
+        *)
+            pkg_arch="${arch}"
+            rust_target="${arch}-unknown-linux-gnu"
+            musl_target="${arch}-unknown-linux-musl"
+            musl_toolchain="${arch}-linux-musl-cross.tgz"
+    esac
+
+    echo "Adding rust target for architecture ${arch}"
+    rustup target add "${rust_target}" "${musl_target}"
+
+    if [ "${arch}" == "${current_arch}" ]; then
+        continue
+    fi
+
+    echo "Installing dependencies for architecture ${arch}"
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        "gcc-${pkg_arch}-linux-gnu" \
+        "g++-${pkg_arch}-linux-gnu" \
+        "libssl-dev:${arch}"
+
+    echo "Installing musl cross compile toolchain for architecture ${arch}"
+    curl -SL -o musl-toolchain.tar.gz "https://musl.cc/${musl_toolchain}"
+    tar -xzf musl-toolchain.tar.gz -C /usr --strip-components=1
+    rm musl-toolchain.tar.gz
+done
+
+echo "Installing goreleaser"
+arch=$(uname -m)
+if [ "${arch}" == "aarch64" ]; then
+    arch="arm64"
+fi
+curl -SL -o goreleaser.tar.gz "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_Linux_${arch}.tar.gz"
+tar -xzf goreleaser.tar.gz -C "/usr/local/bin" goreleaser
+rm goreleaser.tar.gz
+goreleaser --version
+
+echo "Cleaning up"
+apt-get clean
+rm -rf /var/lib/apt/lists/* /var/cache/apt/*

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -4,9 +4,8 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-# TODO: Update folders and files to be removed, same as .gitignore
-folders=("target" "bin" "dist" "coverprofiles" "tmp" "x86_64" "aarch64")
-files=("coverprofile.out")
+folders=("target" "bin" "dist" "tmp" "x86_64" "aarch64")
+files=()
 
 for folder in "${folders[@]}"; do
     if ! [ -e "${base_dir}/${folder}" ]; then
@@ -23,5 +22,3 @@ for file in "${files[@]}"; do
     echo "Removing ${file}"
     rm "${base_dir:-.}/${file}"
 done
-
-rm -f "${base_dir:-.}"/packages/openwrt/*.tar.gz

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -4,34 +4,30 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath | xargs dirname)"
 dist_dir="${base_dir}/dist"
-bin_dir="${base_dir}/bin"
-
-echo "Checking if goreleaser is installed:"
-if command -v goreleaser &>/dev/null; then
-    echo "goreleaser is installed"
-    goreleaser="$(command -v goreleaser)"
-else
-    echo "goreleaser is not installed, downloading latest version..."
-    goreleaser="curl -sfL https://goreleaser.com/static/run | bash -s --"
-    LATEST="$(curl -sf https://goreleaser.com/static/latest)"
-    [ -e "${bin_dir}" ] || mkdir "${bin_dir}"
-    curl -SL -o "${bin_dir}/goreleaser.tar.gz" "https://github.com/goreleaser/goreleaser/releases/download/${LATEST}/goreleaser_$(uname -s)_$(uname -m).tar.gz"
-    tar -xzf "${bin_dir}/goreleaser.tar.gz" -C "${bin_dir}" goreleaser
-    rm "${bin_dir}/goreleaser.tar.gz"
-    goreleaser="${bin_dir}/goreleaser"
-fi
 
 echo "Building releaser artifacts with goreleaser"
-${goreleaser} release --skip=announce,publish,validate --clean
+podman run --name cloudflare-dyndns-builder --rm -v "${base_dir}:/app:z" ghcr.io/heathcliff26/rust-builder:latest goreleaser release --skip=announce,archive,publish,validate --clean
 
-echo "Cleaning up dist directory and artifact names"
-rm "${dist_dir}/artifacts.json" "${dist_dir}/config.yaml" "${dist_dir}/metadata.json" "${dist_dir}"/cloudflare-dyndns_*_checksums.txt
+echo "Moving release artifacts to top level of dist directory"
+artifacts="$(cat "${dist_dir}/artifacts.json" | jq -r -c '.[]')"
+echo "${artifacts}" | while read -r artifact; do
+    if [ "$(echo "${artifact}" | jq -r '.name')" != "cloudflare-dyndns" ]; then
+        continue
+    fi
 
-mv "${dist_dir}/binary_linux_amd64_v1/cloudflare-dyndns" "${dist_dir}/cloudflare-dyndns-amd64"
-mv "${dist_dir}/binary_linux_arm64_v8.0/cloudflare-dyndns" "${dist_dir}/cloudflare-dyndns-arm64"
-mv "${dist_dir}/compressed_linux_amd64_v1/cloudflare-dyndns" "${dist_dir}/cloudflare-dyndns-amd64-compressed"
-mv "${dist_dir}/compressed_linux_arm64_v8.0/cloudflare-dyndns" "${dist_dir}/cloudflare-dyndns-arm64-compressed"
+    path="${base_dir}/$(echo "${artifact}" | jq -r '.path')"
+    goarch="$(echo "${artifact}" | jq -r '.goarch')"
+    id="$(echo "${artifact}" | jq -r '.extra.ID')"
 
-rm -rf "${dist_dir}"/binary_linux_* "${dist_dir}"/compressed_linux_*
+    if [ "${id}" == "dynamic" ]; then
+        mv "${path}" "${dist_dir}/cloudflare-dyndns-${goarch}"
+    else
+        mv "${path}" "${dist_dir}/cloudflare-dyndns-${goarch}-${id}"
+    fi
+    path="$(dirname "${path}")"
+    rm -r "${path}"
+done
 
-echo "Finished building release artifacts, output is in ${dist_dir}"
+
+echo "Cleaning up dist directory"
+rm -r "${dist_dir}/artifacts.json" "${dist_dir}/config.yaml" "${dist_dir}/metadata.json" "${dist_dir}"/cloudflare-dyndns_*_checksums.txt

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ impl Cli {
     }
 }
 
-// TODO: Consider moving the cli options into the specific modules.
 /// cloudflare-dyndns provides DynDNS functionality for cloudflare.
 #[derive(Subcommand)]
 enum Command {


### PR DESCRIPTION
Enable cross-compilation by using a builder image for the toolchains.
Build static and dynamically linked binaries for linux and openwrt targets.