### PR TITLE
CI: Do not publish to crates.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,11 +64,3 @@ jobs:
       artifacts: "cloudflare-dyndns"
       prerelease: ${{ inputs.prerelease }}
     secrets: inherit
-
-  publish-crate:
-    uses: heathcliff26/ci/.github/workflows/cargo-release.yaml@main
-    if: ${{ inputs.draft == false && inputs.update == false }}
-    needs: build
-    permissions:
-      contents: read
-    secrets: inherit


### PR DESCRIPTION
Turns out the name is already used. Since publishing is not as imortant, drop it.