### PR TITLE
helm: Update default memory request

### DIFF
--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -94,7 +94,7 @@ ingress:
 resources:
   requests:
     cpu: 1m
-    memory: 20Mi
+    memory: 5Mi
   # limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
Change memory request to be aligned with new rust implementation. Currently v2.0.0-alpha.0 seems to reliably use less than 5MiB. That seems to be a good default to ensure there is headroom available for future changes and different environments.