### PR TITLE
CI: Add Commit sha to build args

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,8 @@ jobs:
       tag: "${{ inputs.release && needs.extract-version.outputs.version || 'rolling' }}"
       tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
+      build-args: |
+        CI_COMMIT_SHA=${{ github.sha }}
     secrets: inherit
 
   push-helm:


### PR DESCRIPTION
Ensure the container image has the commit sha available.
This ensure the resulting binary has all the needed information for the version subcommand.