### PR TITLE
Add additional unit-tests for uncovered paths

### DIFF
--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -14,6 +14,18 @@ fn test_from_config() {
     );
 }
 
+#[test]
+fn test_from_data() {
+    let data = ClientData::new(true, vec!["example.com".to_string()]);
+    let client = Client::from_data("test-token".to_string(), data);
+    assert_eq!(
+        client.api_url.as_str(),
+        DEFAULT_API_URL,
+        "Should have default API URL"
+    );
+    assert_eq!(client.token, "test-token", "Should have the correct token");
+}
+
 #[tokio::test]
 async fn test_verify_token_success() {
     let (client, http_client, mut server) = new_test_client().await;
@@ -529,6 +541,164 @@ fn test_base_domain() {
     assert_eq!(base_domain("example.com"), "example.com");
     assert_eq!(base_domain("sub.example.com"), "example.com");
     assert_eq!(base_domain("foo.bar.example.com"), "example.com");
+}
+
+#[tokio::test]
+async fn test_get_zone_id_api_error() {
+    let (client, http_client, mut server) = new_test_client().await;
+
+    let zones_mock = server
+        .mock("GET", "/zones?name=example.com&status=active")
+        .with_status(500)
+        .with_body("Internal Server Error")
+        .create();
+
+    let e = client
+        .get_zone_id(&http_client, "foo.example.com")
+        .await
+        .expect_err("Should fail with API error");
+    assert!(
+        e.to_string().contains("Failed to list zones"),
+        "Expected error about listing zones but got: {e}"
+    );
+
+    zones_mock.assert();
+}
+
+#[tokio::test]
+async fn test_update_record_aaaa() {
+    let (client, http_client, mut server) = new_test_client().await;
+
+    let record_mock = server
+        .mock("PATCH", "/zones/zone-id-123/dns_records/record-id-aaaa")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(dns_single_result_response(dns_record_aaaa_json(
+            "record-id-aaaa",
+            "foo.example.com",
+            "fd00::dead",
+        )))
+        .create();
+
+    client
+        .update_record(
+            &http_client,
+            "zone-id-123",
+            "foo.example.com",
+            "record-id-aaaa",
+            RecordType::AAAA,
+        )
+        .await
+        .expect("Should update AAAA dns record");
+
+    record_mock.assert();
+}
+
+#[tokio::test]
+async fn test_create_record_aaaa() {
+    let (client, http_client, mut server) = new_test_client().await;
+
+    let record_mock = server
+        .mock("POST", "/zones/zone-id-123/dns_records")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(dns_single_result_response(dns_record_aaaa_json(
+            "record-aaaa",
+            "foo.example.com",
+            "fd00::dead",
+        )))
+        .create();
+
+    client
+        .create_record(
+            &http_client,
+            "zone-id-123",
+            "foo.example.com",
+            RecordType::AAAA,
+        )
+        .await
+        .expect("Should create AAAA dns record");
+
+    record_mock.assert();
+}
+
+#[tokio::test]
+async fn test_send_update_update_record_fails() {
+    let (client, http_client, mut server) = new_test_client().await;
+
+    let zones_mock = server
+        .mock("GET", "/zones?name=example.com&status=active")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(zone_list_response_ok())
+        .create();
+
+    let records = vec![dns_record_a_json("record-a", "example.com", "1.1.1.1")];
+    let records_mock = server
+        .mock("GET", "/zones/zone-id-123/dns_records?name=example.com")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(dns_list_response(records))
+        .create();
+
+    let update_mock = server
+        .mock("PATCH", "/zones/zone-id-123/dns_records/record-a")
+        .with_status(500)
+        .with_body("Internal Server Error")
+        .create();
+
+    let e = client
+        .send_update(&http_client)
+        .await
+        .expect_err("Should fail when update_record fails");
+    assert!(
+        e.to_string()
+            .contains("Failed to update A record for 'example.com'"),
+        "Expected update error but got: {e}"
+    );
+
+    zones_mock.assert();
+    records_mock.assert();
+    update_mock.assert();
+}
+
+#[tokio::test]
+async fn test_send_update_create_record_fails() {
+    let (client, http_client, mut server) = new_test_client().await;
+
+    let zones_mock = server
+        .mock("GET", "/zones?name=example.com&status=active")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(zone_list_response_ok())
+        .create();
+
+    let records_mock = server
+        .mock("GET", "/zones/zone-id-123/dns_records?name=example.com")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(dns_list_response(vec![]))
+        .create();
+
+    let create_mock = server
+        .mock("POST", "/zones/zone-id-123/dns_records")
+        .with_status(500)
+        .with_body("Internal Server Error")
+        .create();
+
+    let e = client
+        .send_update(&http_client)
+        .await
+        .expect_err("Should fail when create_record fails");
+    assert!(
+        e.to_string()
+            .contains("Failed to create A record for 'example.com'"),
+        "Expected create error but got: {e}"
+    );
+
+    zones_mock.assert();
+    records_mock.assert();
+    create_mock.assert();
 }
 
 async fn new_test_client() -> (Client, HttpClient, ServerGuard) {

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -195,6 +195,11 @@ test_invalid_config! {
         Mode::Server,
         "SSL is enabled but cert is empty",
     ),
+    test_config_invalid_log_level: (
+        "invalid-config-log-level.yaml",
+        Mode::Server,
+        "Invalid log level",
+    ),
 }
 
 #[test]
@@ -267,4 +272,32 @@ test_set_log_level! {
     test_set_log_level_warn: ("warn", false),
     test_set_log_level_error: ("error", false),
     test_set_log_level_invalid: ("unknown", true),
+}
+
+#[test]
+fn test_config_empty_path_client_mode() {
+    let error = Config::from_file("", Mode::Client, false);
+    assert!(
+        error.is_err(),
+        "Expected error when using empty path in client mode"
+    );
+    let e = error.unwrap_err();
+    assert!(
+        e.to_string().contains("Failed to read config file at ''"),
+        "Expected file read error but got: {e}"
+    );
+}
+
+#[test]
+fn test_config_empty_path_relay_mode() {
+    let error = Config::from_file("", Mode::Relay, false);
+    assert!(
+        error.is_err(),
+        "Expected error when using empty path in relay mode"
+    );
+    let e = error.unwrap_err();
+    assert!(
+        e.to_string().contains("Failed to read config file at ''"),
+        "Expected file read error but got: {e}"
+    );
 }

--- a/src/config/testdata/invalid-config-log-level.yaml
+++ b/src/config/testdata/invalid-config-log-level.yaml
@@ -1,0 +1,7 @@
+logLevel: "invalid"
+
+client:
+  token: "test-token"
+  domains:
+    - example.org
+  interval: 300

--- a/src/dyndns/test.rs
+++ b/src/dyndns/test.rs
@@ -3,6 +3,19 @@ use tokio::time::timeout;
 use super::*;
 
 #[test]
+fn test_client_data_new() {
+    let data = ClientData::new(true, vec!["example.com".to_string()]);
+    assert!(data.proxy, "Proxy should match constructor argument");
+    assert_eq!(
+        data.domains,
+        vec!["example.com".to_string()],
+        "Domains should match constructor argument"
+    );
+    assert!(data.ipv4().is_empty(), "IPv4 should be empty initially");
+    assert!(data.ipv6().is_empty(), "IPv6 should be empty initially");
+}
+
+#[test]
 fn test_client_data_set_ipv4() {
     let test_cases = vec![("", true), ("not an ip", false), ("100.100.100.100", true)];
     let mut data = ClientData::new(false, vec![]);

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -335,3 +335,22 @@ fn shared_state(domains: Vec<&str>) -> SharedState {
             .collect(),
     }
 }
+
+#[test]
+fn test_server_from_config() {
+    let config = ServerConfig {
+        port: 9090,
+        domains: vec!["example.org".to_string()],
+        ssl: Default::default(),
+    };
+    let server = Server::from_config(config.clone());
+    assert_eq!(server.options.port, config.port, "Port should match config");
+    assert_eq!(
+        server.options.domains, config.domains,
+        "Domains should match config"
+    );
+    assert_eq!(
+        server.options.ssl.enabled, config.ssl.enabled,
+        "SSL setting should match config"
+    );
+}

--- a/src/server/tls.rs
+++ b/src/server/tls.rs
@@ -148,4 +148,21 @@ mod tests {
         let debug_string = format!("{:?}", error);
         assert!(debug_string.contains("ReadKeyError"));
     }
+
+    #[tokio::test]
+    async fn test_tls_listener_bind_key_not_found() {
+        let result = TlsListener::bind(
+            "127.0.0.1:0".parse().unwrap(),
+            "/tmp/non_existent_dyndns_key_file.pem",
+            "/tmp/non_existent_dyndns_cert_file.pem",
+        )
+        .await;
+
+        assert!(result.is_err(), "Should fail when key file does not exist");
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("Expected error but got success"),
+        };
+        assert!(matches!(err, TlsError::ReadKeyError(_)));
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,9 @@ use reqwest::Client;
 use std::time::Duration;
 use tokio::{select, signal, sync::watch};
 
+#[cfg(test)]
+mod test;
+
 /// Listen for SIGINT or SIGTERM signals and notify over the returned channel.
 /// Should be used to gracefully shutdown application loops.
 pub fn new_interrupt_signal(stop_rx: Option<watch::Receiver<()>>) -> watch::Receiver<()> {

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+#[test]
+fn test_new_http_client() {
+    // Verify that the client is created successfully
+    let client = new_http_client();
+    drop(client);
+}
+
+#[tokio::test]
+async fn test_new_interrupt_signal_with_stop_rx() {
+    let (stop_tx, stop_rx) = watch::channel(());
+    let mut shutdown_rx = new_interrupt_signal(Some(stop_rx));
+
+    // Trigger shutdown via the stop channel
+    stop_tx.send(()).expect("Should send stop signal");
+
+    // The shutdown signal should arrive
+    shutdown_rx
+        .changed()
+        .await
+        .expect("Should receive shutdown signal");
+}
+
+#[tokio::test]
+async fn test_new_interrupt_signal_without_stop_rx() {
+    // Verify that a signal listener is created without panicking
+    let _shutdown_rx = new_interrupt_signal(None);
+}


### PR DESCRIPTION
Create additional unit-tests to cover previously untested code branches.

Authored-by: Copilot
Co-Authored-by: Heathcliff <heathcliff@heathcliff.eu>
Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>